### PR TITLE
update Dockerfile, remove mkdir command, WORKDIR  will create if it doen't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.11.5-alpine as base
 ENV GO111MODULE on
 
 RUN apk --no-cache add gcc g++ make ca-certificates git
-RUN mkdir /weaver
 WORKDIR /weaver
 
 ADD go.mod .


### PR DESCRIPTION
as documented [here](https://docs.docker.com/engine/reference/builder/#workdir): 

If the WORKDIR doesn’t exist, it will be created even if it’s not used in any subsequent Dockerfile instruction.

so there is no need `RUN mkdir /weaver`